### PR TITLE
Uncommented .unkink() methods and changed them to .unlink()

### DIFF
--- a/Firmware/_daq_core/shmemIface.py
+++ b/Firmware/_daq_core/shmemIface.py
@@ -49,13 +49,13 @@ class outShmemIface():
         try:
             shmem_A = shared_memory.SharedMemory(name=shmem_name+'_A',create=False, size=shmem_size)
             shmem_A.close()
-            #shmem_A.unkink()
+            shmem_A.unlink()
         except FileNotFoundError as err:
             self.logger.warning("Shared memory not exist")
         try:
             shmem_B = shared_memory.SharedMemory(name=shmem_name+'_B',create=False, size=shmem_size)
             shmem_B.close()
-            #shmem_B.unkink()
+            shmem_B.unlink()
         except FileNotFoundError as err:
             self.logger.warning("Shared memory not exist")
         


### PR DESCRIPTION
## Description
Often during restarting KrakenSDR as a service happens the following error:
```python
Traceback (most recent call last):
  File "/root/miniconda/envs/kraken/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/root/miniconda/envs/kraken/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/root/miniconda/envs/kraken/lib/python3.9/site-packages/debugpy/__main__.py", line 39, in <module>
    cli.main()
  File "/root/miniconda/envs/kraken/lib/python3.9/site-packages/debugpy/server/cli.py", line 430, in main
    run()
  File "/root/miniconda/envs/kraken/lib/python3.9/site-packages/debugpy/server/cli.py", line 284, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/root/miniconda/envs/kraken/lib/python3.9/site-packages/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 321, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/root/miniconda/envs/kraken/lib/python3.9/site-packages/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 135, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/root/miniconda/envs/kraken/lib/python3.9/site-packages/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code
    exec(code, run_globals)
  File "_daq_core/delay_sync.py", line 825, in <module>
    if delay_synchronizer_inst0.open_interfaces() == 0:
  File "_daq_core/delay_sync.py", line 253, in open_interfaces
    self.out_shmem_iface_iq = outShmemIface("delay_sync_iq",
  File "/root/krakensdr/heimdall_daq_fw/Firmware/_daq_core/shmemIface.py", line 63, in __init__
    self.memories.append(shared_memory.SharedMemory(name=shmem_name+'_A',create=True, size=shmem_size))
  File "/root/miniconda/envs/kraken/lib/python3.9/multiprocessing/shared_memory.py", line 103, in __init__
    self._fd = _posixshmem.shm_open(
FileExistsError: [Errno 17] File exists: '/delay_sync_iq_A'
```
It happens because actually shared memory deleted after `unlink` method called

This PR uncomment `unkink` methods and changed it to proper `unlink`