### PR TITLE
Allow to enable AGC

### DIFF
--- a/Firmware/_daq_core/hw_controller.py
+++ b/Firmware/_daq_core/hw_controller.py
@@ -68,6 +68,8 @@ class HWC():
         self.gain_lock_interval = 0 # Required num. of frames to finish gain tuning
         self.unified_gain_control = True # Gain values will be equal for all the receivers
         self.last_gains=[0]*self.M # Stores the gain values to reset them after calibration
+        self.agc=False
+        self.last_agc=False
         
         # Support for calibration track mode 
         self.cal_track_mode = 0
@@ -237,6 +239,16 @@ class HWC():
             self.in_shmem_iface.destory_sm_buffer()
             
         self.logger.info("Module interfaces are closed")
+
+
+    def _enable_agc(self):
+        if self.agc:
+            msg_byte_array = inter_module_messages.pack_msg_enable_agc(self.module_identifier)
+            self.rtl_daq_socket.send(msg_byte_array)
+            reply = self.rtl_daq_socket.recv()
+            self.logger.debug(f"Received reply: {reply}")
+
+
     def _change_gains(self):
         """
             Sends gain tuning request to the receiver module through the 
@@ -327,6 +339,13 @@ class HWC():
                     self._change_gains()
             except ValueError:
                 self.logger.error("Improper gain value {:d}".format(params[m]))
+        elif command == "AGC ":
+            if self.noise_source_state: # The noise source is turned on, we are only storing the AGC state
+                self.last_agc = True
+            else:
+                self.agc = True
+                self._enable_agc()
+
     
     def _control_noise_source(self, noise_source_state):
         """
@@ -345,6 +364,9 @@ class HWC():
         if noise_source_state:
             self.logger.info("Set gain values to perform calibration") 
             
+            self.last_agc = self.agc
+            self.agc = False
+
             for m in range(self.M):
                 self.last_gains[m]=self.gains[m]
                 self.gains[m]=self.cal_gain_table[1,np.argmin(abs(self.cal_gain_table[0,:]-self.iq_header.rf_center_freq))]
@@ -369,6 +391,10 @@ class HWC():
             for m in range(self.M):                
                 self.gains[m] = self.last_gains[m]
             self._change_gains()
+
+            self.logger.info("Restore AGC state after calibration")
+            self.agc = self.last_agc
+            self._enable_agc()
 
             self.current_state = "STATE_NOISE_CTR_WAIT"
 
@@ -625,7 +651,7 @@ class CtrIfaceServer(threading.Thread):
         """
         ctr_request_condition.acquire()
         command = msg_bytes[0:4].decode()
-
+        self.logger.warning("Got command %s", command)
         if command == "EXIT":
             ctr_request_condition.release()
             return -1
@@ -635,14 +661,14 @@ class CtrIfaceServer(threading.Thread):
             self.logger.info("Received threshold value: {:f}".format(threshold))
             ctr_request.clear()
             ctr_request.append(command)
-            ctr_request.append(threshold)            
+            ctr_request.append(threshold)
 
         elif command == "FREQ":
             frequency = unpack('Q',msg_bytes[4:12])[0]
             self.logger.info("Received frequency value: {:f} Hz".format(frequency))
             ctr_request.clear()
             ctr_request.append(command)
-            ctr_request.append(frequency)            
+            ctr_request.append(frequency)
 
         elif command == "GAIN":
             gains = unpack('I'*self.M, msg_bytes[4:4+4*self.M])
@@ -651,6 +677,11 @@ class CtrIfaceServer(threading.Thread):
             for m in range(self.M):
                 self.logger.info("Received gain values - CH{:d}: {:d} dB x 10".format(m, gains[m]))            
                 ctr_request.append(gains[m])
+
+        elif command == "AGC ":
+            self.logger.info("Received AGC request")
+            ctr_request.clear()
+            ctr_request.append(command)
 
         elif command == "INIT":
             self.logger.info("Inititalization command received")

--- a/Firmware/_daq_core/inter_module_messages.py
+++ b/Firmware/_daq_core/inter_module_messages.py
@@ -80,6 +80,29 @@ def pack_msg_set_gain(module_identifier, gains):
         msg_byte_array +=pack('b',0)    
     return msg_byte_array
 
+
+def pack_msg_enable_agc(module_identifier):
+    """
+        Prepares the byte array of an inter-module ZMQ message for enabling
+        automatic gain control.
+
+        Parameters:
+        -----------
+            :param: module_identifier: Source module id
+
+        Return:
+        -------
+            Assembled message structure in byte array
+    """
+    msg_length = 128 # Total message length 128 byte
+    msg_byte_array  = pack("b", module_identifier) # 1byte
+    msg_byte_array += 'a'.encode('ascii') # 1 byte
+    for _ in range(msg_length-1-1):
+        msg_byte_array +=pack('b',0)
+
+    return msg_byte_array
+
+
 def pack_msg_noise_source_ctr(module_identifier, state):
     """
         Prepares the byte array of an inter-module ZMQ message for internal noise source control
@@ -110,7 +133,7 @@ def pack_msg_noise_source_ctr(module_identifier, state):
 def pack_msg_sample_freq_tune(module_identifier, fs_ppm_offsets):
     """
         Prepares the byte array of an inter-module ZMQ message for sampling frequency ppm offset seting.
-        
+
         Parameters:
         -----------
             :param: module_identifier: Source module id
@@ -121,7 +144,7 @@ def pack_msg_sample_freq_tune(module_identifier, fs_ppm_offsets):
 
         Return:
         -------
-            Assembled message structure in byte array 
+            Assembled message structure in byte array
     """    
     msg_length = 128 # Total message length 128 byte
     msg_byte_array  = pack("b", module_identifier) # 1byte

--- a/Firmware/_daq_core/rtl_daq.h
+++ b/Firmware/_daq_core/rtl_daq.h
@@ -85,7 +85,7 @@ struct hdaq_im_msg_struct {
 };
 
 struct rtl_rec_struct {
-    int dev_ind, gain;
+    int dev_ind, gain, agc;
     rtlsdr_dev_t *dev;
     uint8_t *buffer;   
     unsigned long long buff_ind;


### PR DESCRIPTION
Lets add `AGC` command to hwc and lower level `a` command to `rtl_daq` to allow for enabling (what appears to be RF only) hardware automatic gain control.