### PR TITLE
fix invalid bash syntax

### DIFF
--- a/Firmware/daq_start_sm.sh
+++ b/Firmware/daq_start_sm.sh
@@ -113,10 +113,10 @@ chrt -f 99 python3 _daq_core/delay_sync.py 2> _logs/delay_sync.log &
 chrt -f 99 sudo env "PATH=$PATH" python3 _daq_core/hw_controller.py 2> _logs/hwc.log &
 # root priviliges are needed to drive the i2c master
 
-if [ $out_data_iface_type = eth ]; then
+if [[ $out_data_iface_type == "eth" ]]; then
     echo "Output data interface: IQ ethernet server"
     chrt -f 99 _daq_core/iq_server.out 2>_logs/iq_server.log &
-elif [ $out_data_iface_type = shmem ]; then
+elif [[ $out_data_iface_type == "shmem" ]]; then
     echo "Output data interface: Shared memory"
 fi
 


### PR DESCRIPTION
I ran into [this issue](https://github.com/krakenrf/gr-krakensdr/issues/4) when using the gr-krakensdr GNURadio module. I wasn't able to use the KrakenSDR Source block, I realized that one of the scripts in the heimdall_daq uses Bash, but the syntax wasn't fully correct.

Something similar here #19, but I found fixing the syntax resolve my issues.